### PR TITLE
Limit thread count for NumPy/OpenBLAS/MKL

### DIFF
--- a/dataprocess/extract_av2.py
+++ b/dataprocess/extract_av2.py
@@ -14,7 +14,9 @@
 """
 
 import os
-os.environ["OMP_NUM_THREADS"] = "1"
+# Limit thread count for NumPy/OpenBLAS/MKL - prevents single process from using all cores
+for _k in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS", "NUMEXPR_MAX_THREADS"):
+    os.environ[_k] = "1"
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning)
 


### PR DESCRIPTION
Set environment variables to limit thread count for NumPy and related libraries.  

In certain environments, OpenBLAS/MKL may still have thread pooling.